### PR TITLE
chore(): change dependencies 4.0.1 to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
     "release": "standard-version"
   },
   "devDependencies": {
-    "@capacitor/android": "4.0.1",
-    "@capacitor/cli": "4.0.1",
-    "@capacitor/core": "4.0.1",
+    "@capacitor/android": "^4.0.0",
+    "@capacitor/cli": "^4.0.0",
+    "@capacitor/core": "^4.0.0",
     "@capacitor/docgen": "0.2.0",
-    "@capacitor/ios": "4.0.1",
+    "@capacitor/ios": "^4.0.0",
     "@ionic/eslint-config": "0.3.0",
     "@ionic/prettier-config": "1.0.1",
     "@ionic/swiftlint-config": "1.1.2",


### PR DESCRIPTION
Capacitor versions for the future should not be fixed except for major versions.