### PR TITLE
FIX: iOS black screen when camera overview turned on

### DIFF
--- a/ios/Plugin/PrivacyScreen.swift
+++ b/ios/Plugin/PrivacyScreen.swift
@@ -27,7 +27,6 @@ import UIKit
         } else {
             self.privacyViewController!.view.backgroundColor = .gray
         }
-        self.privacyViewController!.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
 
         super.init()
         if config.enable {

--- a/ios/Plugin/PrivacyScreenPlugin.swift
+++ b/ios/Plugin/PrivacyScreenPlugin.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Capacitor
+import AVFoundation
 
 /**
  * Please read the Capacitor iOS Plugin Development Guide
@@ -23,6 +24,10 @@ public class PrivacyScreenPlugin: CAPPlugin {
                                                name: UIApplication.userDidTakeScreenshotNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleDidChangeStatusBarOrientationNotification),
                                                name: UIApplication.didChangeStatusBarOrientationNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleCameraStartNotification),
+                                               name: .AVCaptureSessionDidStartRunning, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleCameraStopNotification),
+                                               name: .AVCaptureSessionDidStopRunning, object: nil)
     }
 
     deinit {
@@ -65,6 +70,14 @@ public class PrivacyScreenPlugin: CAPPlugin {
 
     @objc private func handleDidChangeStatusBarOrientationNotification() {
         implementation?.handleDidChangeStatusBarOrientationNotification()
+    }
+
+    @objc private func handleCameraStartNotification() {
+        implementation?.handleCameraStartNotification()
+    }
+
+    @objc private func handleCameraStopNotification() {
+        implementation?.handleCameraStopNotification()
     }
 
     private func getPrivacyScreenConfig() -> PrivacyScreenConfig {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x ] The changes have been tested successfully.

### 1) Camera Plugin
As you mentioned in description

```
### Using the Camera Plugin

Disabling screenshots can interfere with plugins that hide the WebView like the Camera plugin. To avoid issues call `disable` before using a plugin and then `enable` after you are finished.

```

we can listen for `AVCaptureSessionDidStartRunning ` and `AVCaptureSessionDidStopRunning ` and enable screenshots without `disabling` and `enabling` Privacy mode

### 2) Blur effect instead of default grey