### PR TITLE
fix(ios): empty `imageName` leads to whitescreen

### DIFF
--- a/ios/Plugin/PrivacyScreen.swift
+++ b/ios/Plugin/PrivacyScreen.swift
@@ -57,7 +57,7 @@ import UIKit
 
     private static func createPrivacyViewController(config: PrivacyScreenConfig) -> UIViewController {
         let privacyViewController = UIViewController()
-        if let imageName = config.imageName {
+        if let imageName = config.imageName, !imageName.isEmpty {
             privacyViewController.view.backgroundColor = UIColor.systemBackground
 
             let imageView = UIImageView()


### PR DESCRIPTION
Close #80 