### PR TITLE
fix(ios): Present the privacyViewController on the top ViewController

### DIFF
--- a/ios/Plugin/PrivacyScreen.swift
+++ b/ios/Plugin/PrivacyScreen.swift
@@ -41,7 +41,9 @@ import UIKit
             return
         }
         DispatchQueue.main.async {
-            let window = UIApplication.shared.connectedScenes.filter({$0.activationState == .foregroundActive || $0.activationState == .foregroundInactive}).compactMap({$0 as? UIWindowScene}).first?.windows.filter({$0.isKeyWindow}).first
+            let window = UIApplication.shared.connectedScenes
+                .filter({$0.activationState == .foregroundActive || $0.activationState == .foregroundInactive})
+                .compactMap({$0 as? UIWindowScene}).first?.windows.filter({$0.isKeyWindow}).first
             if var rootVC = window?.rootViewController {
                 while let topVC = rootVC.presentedViewController {
                     rootVC = topVC

--- a/ios/Plugin/PrivacyScreen.swift
+++ b/ios/Plugin/PrivacyScreen.swift
@@ -41,7 +41,15 @@ import UIKit
             return
         }
         DispatchQueue.main.async {
-            self.plugin.bridge?.viewController?.present(self.privacyViewController, animated: false, completion: nil)
+            let window = UIApplication.shared.connectedScenes.filter({$0.activationState == .foregroundActive || $0.activationState == .foregroundInactive}).compactMap({$0 as? UIWindowScene}).first?.windows.filter({$0.isKeyWindow}).first
+            if var rootVC = window?.rootViewController {
+                while let topVC = rootVC.presentedViewController {
+                    rootVC = topVC
+                }
+                rootVC.present(self.privacyViewController, animated: false, completion: nil)
+            } else {
+                self.plugin.bridge?.viewController?.present(self.privacyViewController, animated: false, completion: nil)
+            }
         }
     }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.

closes https://github.com/capacitor-community/privacy-screen/issues/42

Instead of presenting in the `bridge?.viewController`, get the topmost ViewController and present on it, so it hides any other presented ViewController