### PR TITLE
refactor(ios): Remove unused code

### DIFF
--- a/ios/Plugin/PrivacyScreenPlugin.swift
+++ b/ios/Plugin/PrivacyScreenPlugin.swift
@@ -50,12 +50,10 @@ public class PrivacyScreenPlugin: CAPPlugin {
     }
 
     @objc private func handleCapturedDidChangeNotification() {
-        if #available(iOS 11.0, *) {
-            if UIScreen.main.isCaptured {
-                self.notifyListeners("screenRecordingStarted", data: nil)
-            } else {
-                self.notifyListeners("screenRecordingStopped", data: nil)
-            }
+        if UIScreen.main.isCaptured {
+            self.notifyListeners("screenRecordingStarted", data: nil)
+        } else {
+            self.notifyListeners("screenRecordingStopped", data: nil)
         }
     }
 

--- a/ios/PluginTests/PrivacyScreenPluginTests.swift
+++ b/ios/PluginTests/PrivacyScreenPluginTests.swift
@@ -2,15 +2,6 @@ import XCTest
 @testable import Plugin
 
 class PrivacyScreenTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
 
     func testEcho() {
         // This is an example of a functional test case for a plugin.


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.

The plugin is for Capacitor 5, so iOS 11 is no longer supported and the code iOS 11 version check is not needed

The setUp and tearDown methods are removed by swiftlint when running fmt script.