### PR TITLE
Fix iOS crash #88

### DIFF
--- a/ios/Plugin/PrivacyScreen.swift
+++ b/ios/Plugin/PrivacyScreen.swift
@@ -60,6 +60,9 @@ import UIKit
         guard self.isEnabled else {
             return
         }
+        guard privacyViewController.presentingViewController == nil else {
+            return
+        }
         DispatchQueue.main.async {
             let window = UIApplication.shared.connectedScenes
                 .filter({$0.activationState == .foregroundActive || $0.activationState == .foregroundInactive})


### PR DESCRIPTION
Fixes #88 

Ensure the privacyViewController is never presented on itself. 

The order of the `didBecomeActiveNotification` and `willResignActiveNotification` events is not guaranteed by the OS. Therefore, it is possible that in rare occasions the order of events is unexpected, e.g.: `willResignActiveNotification`, `willResignActiveNotification`, `didBecomeActiveNotification`. This then caused the view to be presented on itself, which crashed the app.

The proper solution would be to use the corresponding synchronous callbacks from UIApplicationDelegate, where the order is guaranteed. As we are in the context of a plugin, we do not have a reasonable way to hook into those callbacks. 

The trade-off with this fix is, that worst case the privacy cover is not shown (instead of the app crashing)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
