### PR TITLE
add foreground/background events to privacy plugin

### DIFF
--- a/ios/Plugin/PrivacyScreenConfig.swift
+++ b/ios/Plugin/PrivacyScreenConfig.swift
@@ -1,8 +1,9 @@
 import Foundation
 
 public struct PrivacyScreenConfig {
-    var enable = true
+    var enable: Bool = true
     var imageName: String? = ""
     var contentMode: String? = "center"
     var preventScreenshots: Bool? = true
+    var foregroundBackgroundEvent: Bool? = false
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -50,6 +50,18 @@ declare module '@capacitor/cli' {
        * @since 5.2.0
        */
       preventScreenshots?: boolean;
+      /**
+       * Configure whether the plugin should use Foreground/Background events [UIScene for iOS 13+) for triggering.
+       *
+       * Only available for iOS.
+       *
+       * @default false
+       * @example false
+       * @since 5.2.0
+       * @see https://developer.apple.com/documentation/uikit/uiscene/3197922-didenterbackgroundnotification
+       * @see https://developer.apple.com/documentation/uikit/uiscene/3197925-willenterforegroundnotification/
+       */
+      foregroundBackgroundEvent?: boolean;
     };
   }
 }


### PR DESCRIPTION
As discussed, to fix the issue #108 , I add to show the privacy controller with a different principle.
I now use UIWindow.

In reality, it works too with current events (didBecomeActiveNotification & willResignActiveNotification). However, I keep current implementation to avoid any regression issue.

I have few more improvement to bring to this plugin, like manage privacy color, add a blur mode, etc. Will be done is next PR.